### PR TITLE
Support time[tz] data type

### DIFF
--- a/lib/pg_column_byte_packer.rb
+++ b/lib/pg_column_byte_packer.rb
@@ -89,9 +89,9 @@ module PgColumnBytePacker
       # doesn't match the canonical name in pg_type; e.g., "float8" is
       # canonical, but pgdump outputs "double precision".
       case bare_type
-      when "bigint", "double precision", /\Atimestamp.*/, /\Abigserial( primary key)?/
+      when "bigint", "double precision", /\Atimestamp(tz| with time zone| without time zone)?/, /\Abigserial( primary key)?/
         8 # Actual alignment for these types.
-      when "integer", "date", /\Adecimal(\([^\)]+\))?/, "real", /\Aserial( primary key)?/
+      when "integer", "date", /\Atime(tz| with time zone| without time zone)?/, /\Adecimal(\([^\)]+\))?/, "real", /\Aserial( primary key)?/
         # Note: unlike the others which always take a fixed amount of space,
         # the numeric/decimal type is stored in a variable amount of space (see:
         # https://www.postgresql.org/docs/10/datatype-numeric.html) but pg_type

--- a/spec/pg_dump_spec.rb
+++ b/spec/pg_dump_spec.rb
@@ -290,6 +290,54 @@ RSpec.describe PgColumnBytePacker::PgDump do
       expect(ordered_columns).to eq(["a_date", "b_int4", "c_int4", "d_date"])
     end
 
+    it "orders time after int8" do
+      ActiveRecord::Base.connection.execute <<~SQL
+        CREATE TABLE tests (
+          a_time time,
+          b_int8 bigint,
+          c_int8 bigint,
+          d_time time
+        )
+      SQL
+
+      dump_table_definitions_and_restore_reordered()
+
+      ordered_columns = column_order_from_postgresql(table: "tests")
+      expect(ordered_columns).to eq(["b_int8", "c_int8", "a_time", "d_time"])
+    end
+
+    it "orders time along with int4" do
+      ActiveRecord::Base.connection.execute <<~SQL
+        CREATE TABLE tests (
+          d_time time,
+          b_int4 integer,
+          a_time time,
+          c_int4 integer
+        )
+      SQL
+
+      dump_table_definitions_and_restore_reordered()
+
+      ordered_columns = column_order_from_postgresql(table: "tests")
+      expect(ordered_columns).to eq(["a_time", "b_int4", "c_int4", "d_time"])
+    end
+
+    it "orders timetz along with int4" do
+      ActiveRecord::Base.connection.execute <<~SQL
+        CREATE TABLE tests (
+          d_time timetz,
+          b_int4 integer,
+          a_time timetz,
+          c_int4 integer
+        )
+      SQL
+
+      dump_table_definitions_and_restore_reordered()
+
+      ordered_columns = column_order_from_postgresql(table: "tests")
+      expect(ordered_columns).to eq(["a_time", "b_int4", "c_int4", "d_time"])
+    end
+
     it "orders byteas after int8" do
       ActiveRecord::Base.connection.execute <<~SQL
         CREATE TABLE tests (

--- a/spec/schema_statements_spec.rb
+++ b/spec/schema_statements_spec.rb
@@ -188,6 +188,30 @@ RSpec.describe PgColumnBytePacker::SchemaCreation do
       expect(ordered_columns).to eq(["a_date", "b_int4", "c_int4", "d_date"])
     end
 
+    it "orders time after int8" do
+      migration.create_table(:tests, :id => false) do |t|
+        t.time :a_time
+        t.integer :b_int8, :limit => 8
+        t.integer :c_int8, :limit => 8
+        t.time :d_time
+      end
+
+      ordered_columns = column_order_from_postgresql(table: "tests")
+      expect(ordered_columns).to eq(["b_int8", "c_int8", "a_time", "d_time"])
+    end
+
+    it "orders time along with int4" do
+      migration.create_table(:tests, :id => false) do |t|
+        t.time :d_time
+        t.integer :b_int4, :limit => 4
+        t.time :a_time
+        t.integer :c_int4, :limit => 4
+      end
+
+      ordered_columns = column_order_from_postgresql(table: "tests")
+      expect(ordered_columns).to eq(["a_time", "b_int4", "c_int4", "d_time"])
+    end
+
     it "orders byteas after int8" do
       migration.create_table(:tests, :id => false) do |t|
         t.binary :a_bytea


### PR DESCRIPTION
I believe this is the last of the built-in data types that have special
representations in their formatted form that we don't already support.
Just like timestamp the `with time zone` and `without time zone`
qualifiers are expected in the formatted form.

Along the way I made the timestamp type name matcher a bit more specific
to avoid accidentally matching user types.