### PR TITLE
Fix ordering of booleans

### DIFF
--- a/lib/pg_column_byte_packer.rb
+++ b/lib/pg_column_byte_packer.rb
@@ -144,12 +144,14 @@ module PgColumnBytePacker
         else
           8 # Default is double precision
         end
-      when "smallint", "boolean"
-        2 # Actual alignment for these types.
       else
         type_without_modifier, modifier = bare_type.match(/\A([^\(]+)(\([^\)]+\))?/)[1..-1]
 
         pg_type_typname = case type_without_modifier
+        when "boolean"
+          "bool"
+        when "smallint"
+          "int2"
         when "character"
           "char"
         else

--- a/spec/pg_dump_spec.rb
+++ b/spec/pg_dump_spec.rb
@@ -708,12 +708,12 @@ RSpec.describe PgColumnBytePacker::PgDump do
       expect(ordered_columns).to eq(["b_text", "c_text", "a_smallint", "d_smallint"])
     end
 
-    it "orders boolean after text" do
+    it "orders boolean after smallint" do
       ActiveRecord::Base.connection.execute <<~SQL
         CREATE TABLE tests (
           a_boolean boolean,
-          b_text text,
-          c_text text,
+          b_int smallint,
+          c_int smallint,
           d_boolean boolean
         )
       SQL
@@ -721,23 +721,7 @@ RSpec.describe PgColumnBytePacker::PgDump do
       dump_table_definitions_and_restore_reordered()
 
       ordered_columns = column_order_from_postgresql(table: "tests")
-      expect(ordered_columns).to eq(["b_text", "c_text", "a_boolean", "d_boolean"])
-    end
-
-    it "orders boolean along with smallint" do
-      ActiveRecord::Base.connection.execute <<~SQL
-        CREATE TABLE tests (
-          d_boolean boolean,
-          b_smallint smallint,
-          a_boolean boolean,
-          c_smallint smallint
-        )
-      SQL
-
-      dump_table_definitions_and_restore_reordered()
-
-      ordered_columns = column_order_from_postgresql(table: "tests")
-      expect(ordered_columns).to eq(["a_boolean", "b_smallint", "c_smallint", "d_boolean"])
+      expect(ordered_columns).to eq(["b_int", "c_int", "a_boolean", "d_boolean"])
     end
 
     it "orders char after smallint" do
@@ -754,6 +738,22 @@ RSpec.describe PgColumnBytePacker::PgDump do
 
       ordered_columns = column_order_from_postgresql(table: "tests")
       expect(ordered_columns).to eq(["b_smallint", "c_smallint", "a_char", "d_char"])
+    end
+
+    it "orders char along with bool" do
+      ActiveRecord::Base.connection.execute <<~SQL
+        CREATE TABLE tests (
+          d_boolean bool,
+          b_char char,
+          a_boolean bool,
+          c_char char
+        )
+      SQL
+
+      dump_table_definitions_and_restore_reordered()
+
+      ordered_columns = column_order_from_postgresql(table: "tests")
+      expect(ordered_columns).to eq(["a_boolean", "b_char", "c_char", "d_boolean"])
     end
 
     it "orders char(n) with char" do

--- a/spec/schema_statements_spec.rb
+++ b/spec/schema_statements_spec.rb
@@ -478,28 +478,16 @@ RSpec.describe PgColumnBytePacker::SchemaCreation do
       expect(ordered_columns).to eq(["b_text", "c_text", "a_smallint", "d_smallint"])
     end
 
-    it "orders boolean after text" do
+    it "orders boolean after smallint" do
       migration.create_table(:tests, :id => false) do |t|
         t.boolean :a_boolean
-        t.text :b_text
-        t.text :c_text
+        t.integer :b_int, :limit => 2
+        t.integer :c_int, :limit => 2
         t.boolean :d_boolean
       end
 
       ordered_columns = column_order_from_postgresql(table: "tests")
-      expect(ordered_columns).to eq(["b_text", "c_text", "a_boolean", "d_boolean"])
-    end
-
-    it "orders boolean along with smallint" do
-      migration.create_table(:tests, :id => false) do |t|
-        t.boolean :d_boolean
-        t.integer :b_smallint, :limit => 2
-        t.boolean :a_boolean
-        t.integer :c_smallint, :limit => 2
-      end
-
-      ordered_columns = column_order_from_postgresql(table: "tests")
-      expect(ordered_columns).to eq(["a_boolean", "b_smallint", "c_smallint", "d_boolean"])
+      expect(ordered_columns).to eq(["b_int", "c_int", "a_boolean", "d_boolean"])
     end
 
     it "orders by name for multiple fields of the same type" do


### PR DESCRIPTION
There was a long-standing bug here which treated booleans and smallints
the same way, but booleans only take up 1 byte, not two, and they don't
need any alignment, so treating them with the 2 byte stored (and
aligned) smallint isn't correct. It's possible this is a holdover from
way-back-when and it was originally just a rough ordering not directly
based on actual alignment, but in any case, the comment about it being
the actual required alignment wasn't correct.